### PR TITLE
Fix end range in bin calculation.

### DIFF
--- a/bam/bam.go
+++ b/bam/bam.go
@@ -121,7 +121,7 @@ func Read(bai io.Reader, region genomics.Region) ([]*bgzf.Chunk, error) {
 		return nil, fmt.Errorf("reading reference count: %v", err)
 	}
 
-	bins := binsForRange(region.Start, maximumReadLength)
+	bins := binsForRange(region.Start, region.End)
 
 	header := &bgzf.Chunk{End: bgzf.LastAddress}
 	chunks := []*bgzf.Chunk{header}


### PR DESCRIPTION
This was resulting in the end range not being applied and too much data being
returned.