### PR TITLE
htsget-server: Add bucket whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ Note that you will require versions of `samtools` and `htslib` that support the
 environment variables used above (`CURL_CA_BUNDLE` and `HTS_AUTH_LOCATION`).
 This support was added in October of 2017.
 
+## Bucket Whitelist
+
+In both secure and insecure mode the list of buckets from which the server is
+allowed to read from can be restricted by passing a comma-separated list of
+buckets via the `--buckets` flag. If the `--buckets` flag is not specified then
+there is no restriction on the buckets from which the server can read.
+
 # Known Issues
 
 * The server isn't very efficient at limiting what reads are returned.  This is

--- a/htsget-server/main.go
+++ b/htsget-server/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/googlegenomics/htsget/analytics"
@@ -33,6 +34,8 @@ var (
 	secure    = flag.Bool("secure", false, "serve in HTTPS-only mode and forward client bearer tokens")
 	httpsCert = flag.String("https_cert", "", "HTTPS certificate file")
 	httpsKey  = flag.String("https_key", "", "HTTPS key file")
+
+	buckets = flag.String("buckets", "", "if set, restricts reads to a comma-separated list of buckets")
 
 	// Enable or disable anonymous usage tracking.
 	//
@@ -59,6 +62,10 @@ func main() {
 
 	server := api.NewServer(newStorageClient, *blockSize)
 	server.Export(http.DefaultServeMux)
+
+	if *buckets != "" {
+		server.Whitelist(strings.Split(*buckets, ","))
+	}
 
 	handler := http.Handler(http.DefaultServeMux)
 	if *trackUsage {


### PR DESCRIPTION
Add a --buckets flags that allows the server to be restricted to a
specific set of buckets from which it can read.