### PR TITLE
api: Update reference to version 1.0.0 from 0.2rc

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -14,7 +14,7 @@
 
 // Package api implements the htsget readset retrieval API.
 //
-// The version implemented by this package is v0.2rc defined at:
+// The version implemented by this package is v1.0.0 defined at:
 // http://samtools.github.io/hts-specs/htsget.html.
 package api
 


### PR DESCRIPTION
This is just a comment change: we don't currently write the version in the
response.