### PR TITLE
travis: Stop building against golang master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: go
 go:
   - 1.9
-  - master


### PR DESCRIPTION
This more than doubles our build time and we don't really need it.