### PR TITLE
appengine: add appengine application

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -1,0 +1,6 @@
+runtime: go
+api_version: go1
+
+handlers:
+- url: /.*
+  script: _go_app

--- a/appengine/htsget.go
+++ b/appengine/htsget.go
@@ -1,0 +1,19 @@
+package htsget
+
+import (
+	"net/http"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlegenomics/htsget/internal/api"
+	"google.golang.org/appengine"
+)
+
+func init() {
+	mux := http.NewServeMux()
+	api.NewServer(newAppEngineClient, 16*1024*1024).Export(mux)
+	http.HandleFunc("/", mux.ServeHTTP)
+}
+
+func newAppEngineClient(req *http.Request) (*storage.Client, http.Header, error) {
+	return api.NewClientFromBearerToken(req.WithContext(appengine.NewContext(req)))
+}


### PR DESCRIPTION
This is a simple appengine wrapper around the htsget API.