### PR TITLE
appengine: Change block size and limit reads

### DIFF
--- a/appengine/htsget.go
+++ b/appengine/htsget.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	mux := http.NewServeMux()
-	server := api.NewServer(newAppEngineClient, 16*1024*1024)
+	server := api.NewServer(newAppEngineClient, 8*1024*1024)
 	if list := os.Getenv("BUCKET_WHITELIST"); list != "" {
 		server.Whitelist(strings.Split(list, ","))
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -124,7 +124,7 @@ func (server *Server) serveReads(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	data, err := gcs.Bucket(bucket).Object(object).NewReader(ctx)
+	data, err := gcs.Bucket(bucket).Object(object).NewRangeReader(ctx, 0, int64(server.blockSizeLimit))
 	if err != nil {
 		writeError(w, newStorageError("opening data", err))
 		return


### PR DESCRIPTION
It appears that reads without express limits are not well supported while
running on AppEngine.  I haven't (yet) dug into why - I suspect there is
something in the storage library that behaves differently for AppEngine (in
particular, I suspect that unbounded reads result in urlfetch RPCs for the
entire object).

The block size limit is also reduced since the maximum response size from
AppEngine is 10MB.