### PR TITLE
htsget-server: Change default port to 80.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ COPY . .
 RUN go-wrapper download ./...
 RUN go-wrapper install ./...
 
-# The server port can be changed using the --port flag.
-EXPOSE 7152
+EXPOSE 80
 
 # By default, the server listens for plain HTTP requests on the default port
 # (exposed above) and serves requests to public data only.  See the README for

--- a/htsget-server/main.go
+++ b/htsget-server/main.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	port      = flag.Int("port", 7152, "HTTP service port")
+	port      = flag.Int("port", 80, "HTTP service port")
 	blockSize = flag.Uint64("block_size", 1024*1024*1024, "block size soft limit")
 
 	secure    = flag.Bool("secure", false, "serve in HTTPS-only mode and forward client bearer tokens")


### PR DESCRIPTION
This simplifies things when writing example command lines since we can omit the
port from URLs.