### PR TITLE
Refactors out the use of GCS so a different object store can be used

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -179,8 +179,8 @@ func testQuery(ctx context.Context, t *testing.T, url string) *http.Response {
 	if err != nil {
 		t.Fatalf("Failed to create storage client: %v", err)
 	}
-	newStorageClient := func(*http.Request) (*storage.Client, http.Header, error) {
-		return gcs, nil, nil
+	newStorageClient := func(*http.Request) (Client, http.Header, error) {
+		return GCSClient{gcs}, nil, nil
 	}
 
 	mux := http.NewServeMux()

--- a/api/block.go
+++ b/api/block.go
@@ -21,12 +21,11 @@ import (
 	"io"
 	"io/ioutil"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlegenomics/htsget/internal/bgzf"
 )
 
 type blockRequest struct {
-	object *storage.ObjectHandle
+	object ObjectHandle
 	chunk  bgzf.Chunk
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"context"
+	"io"
+)
+
+// Client is an interface to the storage engine.
+type Client interface {
+	// NewObjectHandle returns a handle to a specified object in
+	// the storage engine.
+	NewObjectHandle(bucket, object string) ObjectHandle
+}
+
+// ObjectHandle is an interface to the actual storage engine in use.
+type ObjectHandle interface {
+	// NewRangeReader returns a reader that reads from a specified
+	// range. Length of -1 means to capture everything until the
+	// end.
+	NewRangeReader(ctx context.Context, offset, length int64) (io.ReadCloser, error)
+}

--- a/api/gcs.go
+++ b/api/gcs.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+
+	"cloud.google.com/go/storage"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+// GCSClient is Client for accessing Google Cloud Storage.
+type GCSClient struct {
+	*storage.Client
+}
+
+// NewObjectHandle returns a handle to a specified object in the
+// storage engine.
+func (c GCSClient) NewObjectHandle(bucket, object string) ObjectHandle {
+	return gcsObjectHandle{c.Bucket(bucket).Object(object)}
+}
+
+type gcsObjectHandle struct {
+	*storage.ObjectHandle
+}
+
+func (h gcsObjectHandle) NewRangeReader(ctx context.Context, offset, length int64) (io.ReadCloser, error) {
+	return h.ObjectHandle.NewRangeReader(ctx, offset, length)
+}
+
+var (
+	defaultStorageClient           *storage.Client
+	initializeDefaultStorageClient sync.Once
+)
+
+func newClientWithOptions(opts ...option.ClientOption) (Client, http.Header, error) {
+	initializeDefaultStorageClient.Do(func() {
+		gcs, err := storage.NewClient(context.Background(), opts...)
+		if err != nil {
+			log.Fatalf("Creating default storage client: %v", err)
+		}
+		defaultStorageClient = gcs
+	})
+	return GCSClient{defaultStorageClient}, nil, nil
+}
+
+// NewDefaultClient returns a storage client that uses the application default
+// credentials.  It caches the storage client for efficiency.
+func NewDefaultClient(_ *http.Request) (Client, http.Header, error) {
+	return newClientWithOptions()
+}
+
+// NewPublicClient returns a storage client that does not use any form of
+// client authorization.  It can only be used to read publicly-readable
+// objects. It caches the storage client for efficiency.
+func NewPublicClient(_ *http.Request) (Client, http.Header, error) {
+	return newClientWithOptions(option.WithHTTPClient(http.DefaultClient))
+}
+
+// NewClientFromBearerToken constructs a storage client that uses the OAuth2
+// bearer token found in req to make storage requests.  It returns the
+// authorization header containing the bearer token as well to allow subsequent
+// requests to be authenticated correctly.
+func NewClientFromBearerToken(req *http.Request) (Client, http.Header, error) {
+	authorization := req.Header.Get("Authorization")
+
+	fields := strings.Split(authorization, " ")
+	if len(fields) != 2 || fields[0] != "Bearer" {
+		return nil, nil, errMissingOrInvalidToken
+	}
+
+	token := oauth2.Token{
+		TokenType:   fields[0],
+		AccessToken: fields[1],
+	}
+	client, err := storage.NewClient(req.Context(), option.WithTokenSource(oauth2.StaticTokenSource(&token)))
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating client with token source: %v", err)
+	}
+
+	return GCSClient{client}, map[string][]string{
+		"Authorization": []string{authorization},
+	}, nil
+}
+
+func newStorageError(context string, err error) error {
+	if err == errMissingOrInvalidToken {
+		return newPermissionDeniedError(context, err)
+	}
+	if err == storage.ErrObjectNotExist {
+		return newNotFoundError("object does not exist", err)
+	}
+	if err, ok := err.(*googleapi.Error); ok {
+		switch err.Code {
+		case http.StatusUnauthorized:
+			return newInvalidAuthenticationError(context, err)
+		case http.StatusForbidden:
+			return newPermissionDeniedError(context, err)
+		}
+	}
+	return err
+}

--- a/api/reads.go
+++ b/api/reads.go
@@ -17,24 +17,24 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlegenomics/htsget/internal/bam"
 	"github.com/googlegenomics/htsget/internal/bgzf"
 	"github.com/googlegenomics/htsget/internal/genomics"
 )
 
 type readsRequest struct {
-	indexObjects   []*storage.ObjectHandle
+	indexObjects   []ObjectHandle
 	blockSizeLimit uint64
 	region         genomics.Region
 }
 
 func (req *readsRequest) handle(ctx context.Context) ([]*bgzf.Chunk, error) {
-	var index *storage.Reader
+	var index io.ReadCloser
 	var err error
 	for _, object := range req.indexObjects {
-		index, err = object.NewReader(ctx)
+		index, err = object.NewRangeReader(ctx, 0, -1)
 		if err == nil {
 			break
 		}

--- a/appengine/htsget.go
+++ b/appengine/htsget.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlegenomics/htsget/api"
 	"google.golang.org/appengine"
 )
@@ -20,6 +19,6 @@ func init() {
 	http.HandleFunc("/", mux.ServeHTTP)
 }
 
-func newAppEngineClient(req *http.Request) (*storage.Client, http.Header, error) {
+func newAppEngineClient(req *http.Request) (api.Client, http.Header, error) {
 	return api.NewClientFromBearerToken(req.WithContext(appengine.NewContext(req)))
 }


### PR DESCRIPTION
Google Cloud Storage (GCS) isn't the only object store available and
unlike S3 there isn't a handy drop-in replacement like Minio available
to replace it. By refactoring out the use of GCS into a standard go
interface the entire server becomes much more modular for other
organizations to use.